### PR TITLE
Add GitHub Pages deployment for vhsl-map

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,44 @@
+name: Deploy VHSL Map to GitHub Pages
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: |
+          cd vhsl-map
+          npm install
+      - name: Build
+        run: |
+          cd vhsl-map
+          npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: vhsl-map/dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore build outputs and dependencies for the web map
+vhsl-map/node_modules
+vhsl-map/dist

--- a/vhsl-map/vite.config.js
+++ b/vhsl-map/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import { resolve } from 'path';
 
 export default defineConfig({
+  base: '/vhsl/',
   root: 'src',
   publicDir: '../public',
   build: {


### PR DESCRIPTION
## Summary
- add GitHub Pages workflow to build and deploy the Vite site
- configure Vite with a `/vhsl/` base path
- ignore node modules and build output

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3c2c115483268f7f70634730f849