### PR TITLE
Fix data path resolution for GitHub Pages

### DIFF
--- a/vhsl-map/src/js/main.js
+++ b/vhsl-map/src/js/main.js
@@ -39,9 +39,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   
   try {
     // Load GeoJSON data - use Promise.all for parallel loading
+    const base = import.meta.env.BASE_URL || '/';
     const [schoolsGeoJSON, lookupData] = await Promise.all([
-      fetchData('/data/geojson/all_schools.geojson'),
-      fetchData('/data/geojson/school_lookup.json')
+      fetchData(`${base}data/geojson/all_schools.geojson`),
+      fetchData(`${base}data/geojson/school_lookup.json`)
     ]);
     
     if (!schoolsGeoJSON || !lookupData) {


### PR DESCRIPTION
## Summary
- use `import.meta.env.BASE_URL` so data paths work correctly on GitHub Pages

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3fdcaf9c8326aba7e5baf9e49728