### PR TITLE
Simplify map UI

### DIFF
--- a/vhsl-map/src/index.html
+++ b/vhsl-map/src/index.html
@@ -13,19 +13,6 @@
       <img id="logo" src="./assets/vhsl-logo.png" alt="VHSL Logo">
       <h1>Virginia High School League Map</h1>
     </div>
-    <div class="search-container">
-      <div class="search-wrapper">
-        <input type="text" id="global-search" placeholder="Search schools, regions, or districts...">
-        <button id="search-button" aria-label="Search">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18">
-            <path fill="currentColor" d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 0 0 1.48-5.34c-.47-2.78-2.79-5-5.59-5.34a6.505 6.505 0 0 0-7.27 7.27c.34 2.8 2.56 5.12 5.34 5.59a6.5 6.5 0 0 0 5.34-1.48l.27.28v.79l4.25 4.25c.41.41 1.08.41 1.49 0 .41-.41.41-1.08 0-1.49L15.5 14zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
-          </svg>
-        </button>
-      </div>
-      <div id="search-results" class="hidden">
-        <!-- Populated by JavaScript -->
-      </div>
-    </div>
     <nav>
       <button id="menu-toggle" aria-label="Toggle menu">
         <span class="bar"></span>
@@ -76,10 +63,22 @@
     
     <div id="map-container">
       <div id="map"></div>
+      <div class="search-container">
+        <div class="search-wrapper">
+          <input type="text" id="global-search" placeholder="Search schools, regions, or districts...">
+          <button id="search-button" aria-label="Search">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18">
+              <path fill="currentColor" d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 0 0 1.48-5.34c-.47-2.78-2.79-5-5.59-5.34a6.505 6.505 0 0 0-7.27 7.27c.34 2.8 2.56 5.12 5.34 5.59a6.5 6.5 0 0 0 5.34-1.48l.27.28v.79l4.25 4.25c.41.41 1.08.41 1.49 0 .41-.41.41-1.08 0-1.49L15.5 14zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
+            </svg>
+          </button>
+        </div>
+        <div id="search-results" class="hidden">
+          <!-- Populated by JavaScript -->
+        </div>
+      </div>
       <div id="map-controls">
         <button id="zoom-in" aria-label="Zoom in">+</button>
         <button id="zoom-out" aria-label="Zoom out">-</button>
-        <button id="reset-view" aria-label="Reset view">↻</button>
       </div>
       <div id="info-panel" class="hidden">
         <button id="close-info" aria-label="Close info panel">×</button>

--- a/vhsl-map/src/js/main.js
+++ b/vhsl-map/src/js/main.js
@@ -416,7 +416,7 @@ function jumpToSchool(schoolName) {
     
     // Close sidebar on mobile
     if (window.innerWidth < 768) {
-      document.getElementById('sidebar').classList.remove('active');
+      document.getElementById('sidebar')?.classList.remove('active');
       document.querySelector('.sidebar-overlay')?.classList.remove('active');
       document.getElementById('sidebar-toggle')?.classList.remove('active');
     }
@@ -737,89 +737,48 @@ function initMap(schoolsGeoJSON) {
 
 // Initialize UI components - optimized version
 function initUI() {
-  // Mobile menu toggle
-  const menuToggle = document.getElementById('menu-toggle');
-  const mainNav = document.getElementById('main-nav');
-  
-  menuToggle.addEventListener('click', () => {
-    menuToggle.classList.toggle('active');
-    mainNav.classList.toggle('active');
-  });
-  
-  // Create sidebar toggle for mobile
-  const sidebarToggle = document.createElement('button');
-  sidebarToggle.id = 'sidebar-toggle';
-  sidebarToggle.innerHTML = '<span></span><span></span><span></span>';
-  sidebarToggle.setAttribute('aria-label', 'Toggle sidebar');
-  document.querySelector('main').appendChild(sidebarToggle);
-  
-  // Create sidebar close button for mobile
-  const sidebarClose = document.createElement('button');
-  sidebarClose.id = 'sidebar-close';
-  sidebarClose.innerHTML = '×';
-  sidebarClose.setAttribute('aria-label', 'Close sidebar');
-  document.getElementById('sidebar').appendChild(sidebarClose);
-  
-  // Create overlay for mobile sidebar
-  const sidebarOverlay = document.createElement('div');
-  sidebarOverlay.className = 'sidebar-overlay';
-  document.querySelector('main').appendChild(sidebarOverlay);
-  
-  // Sidebar toggle functionality
-  sidebarToggle.addEventListener('click', () => {
-    document.getElementById('sidebar').classList.add('active');
-    sidebarOverlay.classList.add('active');
-    sidebarToggle.classList.add('active');
-  });
-  
-  // Sidebar close functionality
-  sidebarClose.addEventListener('click', () => {
-    document.getElementById('sidebar').classList.remove('active');
-    sidebarOverlay.classList.remove('active');
-    sidebarToggle.classList.remove('active');
-  });
-  
-  // Close sidebar when clicking overlay
-  sidebarOverlay.addEventListener('click', () => {
-    document.getElementById('sidebar').classList.remove('active');
-    sidebarOverlay.classList.remove('active');
-    sidebarToggle.classList.remove('active');
-  });
-  
-  // Map controls with debounce
-  document.getElementById('zoom-in').addEventListener('click', debounce(() => {
-    const view = map.getView();
-    const zoom = view.getZoom();
-    view.animate({
-      zoom: zoom + 1,
-      duration: 250
+  const zoomIn = document.getElementById('zoom-in');
+  const zoomOut = document.getElementById('zoom-out');
+
+  if (zoomIn) {
+    zoomIn.addEventListener('click', debounce(() => {
+      const view = map.getView();
+      const zoom = view.getZoom();
+      view.animate({
+        zoom: zoom + 1,
+        duration: 250
+      });
+    }, 250));
+  }
+
+  if (zoomOut) {
+    zoomOut.addEventListener('click', debounce(() => {
+      const view = map.getView();
+      const zoom = view.getZoom();
+      view.animate({
+        zoom: zoom - 1,
+        duration: 250
+      });
+    }, 250));
+  }
+
+  const resetView = document.getElementById('reset-view');
+  if (resetView) {
+    resetView.addEventListener('click', debounce(() => {
+      map.getView().animate({
+        center: fromLonLat([-79.5, 37.8]),
+        zoom: 7,
+        duration: 500
+      });
+    }, 250));
+  }
+
+  const closeInfo = document.getElementById('close-info');
+  if (closeInfo) {
+    closeInfo.addEventListener('click', () => {
+      document.getElementById('info-panel').classList.add('hidden');
     });
-  }, 250));
-  
-  document.getElementById('zoom-out').addEventListener('click', debounce(() => {
-    const view = map.getView();
-    const zoom = view.getZoom();
-    view.animate({
-      zoom: zoom - 1,
-      duration: 250
-    });
-  }, 250));
-  
-  document.getElementById('reset-view').addEventListener('click', debounce(() => {
-    map.getView().animate({
-      center: fromLonLat([-79.5, 37.8]),
-      zoom: 7,
-      duration: 500
-    });
-  }, 250));
-  
-  // Close info panel
-  document.getElementById('close-info').addEventListener('click', () => {
-    document.getElementById('info-panel').classList.add('hidden');
-  });
-  
-  // Add legend
-  createLegend();
+  }
 }
 
 // Debounce function to limit how often a function can be called
@@ -990,9 +949,9 @@ function populateSchoolList(schoolLookup) {
         
         // Close sidebar on mobile
         if (window.innerWidth < 768) {
-          document.getElementById('sidebar').classList.remove('active');
-          document.querySelector('.sidebar-overlay').classList.remove('active');
-          document.getElementById('sidebar-toggle').classList.remove('active');
+          document.getElementById('sidebar')?.classList.remove('active');
+          document.querySelector('.sidebar-overlay')?.classList.remove('active');
+          document.getElementById('sidebar-toggle')?.classList.remove('active');
         }
       }
     });

--- a/vhsl-map/src/styles/main.css
+++ b/vhsl-map/src/styles/main.css
@@ -32,6 +32,18 @@ body {
   overflow-x: hidden;
 }
 
+/* Hide navigation and sidebar */
+nav,
+#sidebar,
+#sidebar-toggle,
+#sidebar-close {
+  display: none !important;
+}
+#legend-toggle,
+#map-legend {
+  display: none !important;
+}
+
 /* Header styles */
 header {
   background-color: var(--primary-color);
@@ -64,17 +76,21 @@ header h1 {
 }
 
 /* Search container styles */
+/* Search container now overlays the map */
 .search-container {
-  flex: 1;
-  max-width: 500px;
-  margin: 0 1rem;
-  position: relative;
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 90%;
+  max-width: 400px;
+  z-index: 1001;
 }
 
 .search-wrapper {
   display: flex;
   align-items: center;
-  background-color: rgba(255, 255, 255, 0.15);
+  background-color: rgba(255, 255, 255, 0.9);
   border-radius: var(--border-radius);
   transition: var(--transition);
 }
@@ -88,14 +104,14 @@ header h1 {
   padding: 0.5rem 1rem;
   border: none;
   background: transparent;
-  color: white;
+  color: var(--dark-color);
   font-size: 0.9rem;
   width: 100%;
   border-radius: var(--border-radius) 0 0 var(--border-radius);
 }
 
 #global-search::placeholder {
-  color: rgba(255, 255, 255, 0.7);
+  color: #666;
 }
 
 #global-search:focus {
@@ -111,7 +127,7 @@ header h1 {
   background: transparent;
   border: none;
   padding: 0.5rem;
-  color: white;
+  color: var(--dark-color);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -160,13 +176,15 @@ header h1 {
   background-color: #f5f5f5;
 }
 
+
 .search-result-name {
   font-weight: 500;
+  color: #000;
 }
 
 .search-result-meta {
   font-size: 0.8rem;
-  color: #666;
+  color: #000;
 }
 
 .search-result-actions {
@@ -192,7 +210,7 @@ header h1 {
 .search-no-results {
   padding: 1rem;
   text-align: center;
-  color: #666;
+  color: #000;
 }
 
 nav {


### PR DESCRIPTION
## Summary
- overlay search box on the map
- hide the sidebar, nav menu, legend and reset controls
- keep zoom buttons only
- darken search result text

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6d4709988326886e090673119acb